### PR TITLE
feat: Implement interval-based random delay settings

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,20 @@
+# AGENT.md - Guidelines for AI Agents
+
+## Build and Test Commands
+- Run all tests: `python -m pytest tests/`
+- Run single test: `python -m pytest tests/test_specific.py`
+- Run with specific function: `python -m pytest tests/test_file.py::test_function`
+- Run the application: `python webui.py`
+
+## Code Style Guidelines
+- **Formatting**: Using Ruff for code formatting and linting
+- **Type Checking**: Basic type checking via VSCode settings
+- **Imports**: Use absolute imports from `src.` directories
+- **Type Annotations**: Use Python type hints on function parameters and return values
+- **Docstrings**: Functions should have docstrings with descriptions and parameter documentation
+- **Error Handling**: Use try-except blocks with specific exceptions and logging
+- **Naming**: 
+  - snake_case for variables and functions
+  - PascalCase for classes
+  - ALL_CAPS for constants
+- **Async**: Project uses asyncio for async operations

--- a/src/agent/browser_use/browser_use_agent.py
+++ b/src/agent/browser_use/browser_use_agent.py
@@ -177,7 +177,7 @@ class BrowserUseAgent(Agent):
                 
                 # Process task delay (if applicable for current task/run)
                 # Note: Task delay might not be applicable depending on implementation
-                if step == 1:  # Only apply task delay on first step
+                if step == 0:  # Only apply task delay on first step
                     await self._apply_delay("TASK")
 
                 step_info = AgentStepInfo(step_number=step, max_steps=max_steps)

--- a/src/agent/browser_use/browser_use_agent.py
+++ b/src/agent/browser_use/browser_use_agent.py
@@ -4,11 +4,10 @@ import asyncio
 import logging
 import os
 import random
-<<<<<<< HEAD
+
 from typing import Optional, List, Any
-=======
+
 from typing import Optional, List
->>>>>>> d40bdc8 (feat: Add environment fallback for agent settings in browser_use_agent_tab)
 
 # from lmnr.sdk.decorators import observe
 from browser_use.agent.gif import create_history_gif

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -363,19 +363,20 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         # --- Step Delay Settings ---
         with gr.Row():
             step_enable_random_interval = get_env_value("STEP_ENABLE_RANDOM_INTERVAL", False, bool)
-            step_enable_random_interval_checkbox = gr.Checkbox(
-                label="Enable Random Interval for Step Delay",
+            step_enable_random_interval_switch = gr.Checkbox(
+                label="🎲 Random Interval for Step Delay",
                 value=step_enable_random_interval,
                 interactive=True,
+                elem_classes=["switch-checkbox"]
             )
-        with gr.Row():
+        with gr.Row(visible=step_enable_random_interval) as step_interval_row:
             min_step_delay_slider_minutes = gr.Slider(
                 label="Min Step Delay (minutes)",
                 minimum=0,
                 maximum=1440,
                 value=get_env_value("STEP_MIN_DELAY_MINUTES", 0.0, float),
                 step=1,
-                interactive=step_enable_random_interval,
+                interactive=True,
             )
             max_step_delay_slider_minutes = gr.Slider(
                 label="Max Step Delay (minutes)",
@@ -383,25 +384,26 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 maximum=1440,
                 value=get_env_value("STEP_MAX_DELAY_MINUTES", 0.0, float),
                 step=1,
-                interactive=step_enable_random_interval,
+                interactive=True,
             )
 
         # --- Action Delay Settings ---
         with gr.Row():
             action_enable_random_interval = get_env_value("ACTION_ENABLE_RANDOM_INTERVAL", False, bool)
-            action_enable_random_interval_checkbox = gr.Checkbox(
-                label="Enable Random Interval for Action Delay",
+            action_enable_random_interval_switch = gr.Checkbox(
+                label="🎲 Random Interval for Action Delay",
                 value=action_enable_random_interval,
                 interactive=True,
+                elem_classes=["switch-checkbox"]
             )
-        with gr.Row():
+        with gr.Row(visible=action_enable_random_interval) as action_interval_row:
             min_action_delay_slider_minutes = gr.Slider(
                 label="Min Action Delay (minutes)",
                 minimum=0,
                 maximum=1440,
                 value=get_env_value("ACTION_MIN_DELAY_MINUTES", 0.0, float),
                 step=1,
-                interactive=action_enable_random_interval,
+                interactive=True,
             )
             max_action_delay_slider_minutes = gr.Slider(
                 label="Max Action Delay (minutes)",
@@ -409,25 +411,26 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 maximum=1440,
                 value=get_env_value("ACTION_MAX_DELAY_MINUTES", 0.0, float),
                 step=1,
-                interactive=action_enable_random_interval,
+                interactive=True,
             )
 
         # --- Task Delay Settings ---
         with gr.Row():
             task_enable_random_interval = get_env_value("TASK_ENABLE_RANDOM_INTERVAL", False, bool)
-            task_enable_random_interval_checkbox = gr.Checkbox(
-                label="Enable Random Interval for Task Delay",
+            task_enable_random_interval_switch = gr.Checkbox(
+                label="🎲 Random Interval for Task Delay",
                 value=task_enable_random_interval,
                 interactive=True,
+                elem_classes=["switch-checkbox"]
             )
-        with gr.Row():
+        with gr.Row(visible=task_enable_random_interval) as task_interval_row:
             min_task_delay_slider_minutes = gr.Slider(
                 label="Min Task Delay (minutes)",
                 minimum=0,
                 maximum=1440,
                 value=get_env_value("TASK_MIN_DELAY_MINUTES", 0.0, float),
                 step=1,
-                interactive=task_enable_random_interval,
+                interactive=True,
             )
             max_task_delay_slider_minutes = gr.Slider(
                 label="Max Task Delay (minutes)",
@@ -435,7 +438,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 maximum=1440,
                 value=get_env_value("TASK_MAX_DELAY_MINUTES", 0.0, float),
                 step=1,
-                interactive=task_enable_random_interval,
+                interactive=True,
             )
 
     tab_components.update(
@@ -464,17 +467,17 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             mcp_server_config=mcp_server_config,
             step_delay_minutes=step_delay_slider_minutes,
             custom_step_delay_minutes=custom_step_delay_minutes,
-            step_enable_random_interval=step_enable_random_interval_checkbox,
+            step_enable_random_interval=step_enable_random_interval_switch,
             min_step_delay_minutes=min_step_delay_slider_minutes,
             max_step_delay_minutes=max_step_delay_slider_minutes,
             action_delay_minutes=action_delay_slider_minutes,
             custom_action_delay_minutes=custom_action_delay_minutes,
-            action_enable_random_interval=action_enable_random_interval_checkbox,
+            action_enable_random_interval=action_enable_random_interval_switch,
             min_action_delay_minutes=min_action_delay_slider_minutes,
             max_action_delay_minutes=max_action_delay_slider_minutes,
             task_delay_minutes=task_delay_slider_minutes,
             custom_task_delay_minutes=custom_task_delay_minutes,
-            task_enable_random_interval=task_enable_random_interval_checkbox,
+            task_enable_random_interval=task_enable_random_interval_switch,
             min_task_delay_minutes=min_task_delay_slider_minutes,
             max_task_delay_minutes=max_task_delay_slider_minutes,
         )
@@ -668,52 +671,48 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         save_time_interval_settings
     )
 
-    # --- Define interactivity update logic ---
-    def update_delay_interactivity(checkbox_state):
-        # If checkbox is True (random interval enabled):
-        # - Min/Max sliders are interactive
+    # --- Define visibility and interactivity update logic ---
+    def update_delay_interactivity(switch_state):
+        # If switch is True (random interval enabled):
+        # - Interval row is visible and interactive
         # - Fixed delay inputs are NOT interactive
-        # If checkbox is False (random interval disabled):
-        # - Min/Max sliders are NOT interactive
+        # If switch is False (random interval disabled):
+        # - Interval row is hidden
         # - Fixed delay inputs are interactive
         return [
-            gr.update(interactive=checkbox_state),  # For min_slider
-            gr.update(interactive=checkbox_state),  # For max_slider
-            gr.update(interactive=not checkbox_state),  # For fixed_delay_number_input
-            gr.update(interactive=not checkbox_state),  # For fixed_delay_descriptive_slider
+            gr.update(visible=switch_state),  # For interval row
+            gr.update(interactive=not switch_state),  # For fixed_delay_number_input
+            gr.update(interactive=not switch_state),  # For fixed_delay_descriptive_slider
         ]
 
-    # --- Connect interactivity logic for Step Delay ---
-    step_enable_random_interval_checkbox.change(
+    # --- Connect visibility logic for Step Delay ---
+    step_enable_random_interval_switch.change(
         fn=update_delay_interactivity,
-        inputs=[step_enable_random_interval_checkbox],
+        inputs=[step_enable_random_interval_switch],
         outputs=[
-            min_step_delay_slider_minutes,
-            max_step_delay_slider_minutes,
+            step_interval_row,
             custom_step_delay_minutes,
             step_delay_slider_minutes,
         ],
     )
 
-    # --- Connect interactivity logic for Action Delay ---
-    action_enable_random_interval_checkbox.change(
+    # --- Connect visibility logic for Action Delay ---
+    action_enable_random_interval_switch.change(
         fn=update_delay_interactivity,
-        inputs=[action_enable_random_interval_checkbox],
+        inputs=[action_enable_random_interval_switch],
         outputs=[
-            min_action_delay_slider_minutes,
-            max_action_delay_slider_minutes,
+            action_interval_row,
             custom_action_delay_minutes,
             action_delay_slider_minutes,
         ],
     )
 
-    # --- Connect interactivity logic for Task Delay ---
-    task_enable_random_interval_checkbox.change(
+    # --- Connect visibility logic for Task Delay ---
+    task_enable_random_interval_switch.change(
         fn=update_delay_interactivity,
-        inputs=[task_enable_random_interval_checkbox],
+        inputs=[task_enable_random_interval_switch],
         outputs=[
-            min_task_delay_slider_minutes,
-            max_task_delay_slider_minutes,
+            task_interval_row,
             custom_task_delay_minutes,
             task_delay_slider_minutes,
         ],
@@ -721,9 +720,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
     # --- Connect save logic for new interval components ---
     # Step delay random interval
-    step_enable_random_interval_checkbox.change(
+    step_enable_random_interval_switch.change(
         fn=lambda x: save_time_interval_settings(step_enable_random_interval=x),
-        inputs=[step_enable_random_interval_checkbox],
+        inputs=[step_enable_random_interval_switch],
         outputs=[],
     )
     min_step_delay_slider_minutes.change(
@@ -738,9 +737,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
     )
 
     # Action delay random interval
-    action_enable_random_interval_checkbox.change(
+    action_enable_random_interval_switch.change(
         fn=lambda x: save_time_interval_settings(action_enable_random_interval=x),
-        inputs=[action_enable_random_interval_checkbox],
+        inputs=[action_enable_random_interval_switch],
         outputs=[],
     )
     min_action_delay_slider_minutes.change(
@@ -755,9 +754,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
     )
 
     # Task delay random interval
-    task_enable_random_interval_checkbox.change(
+    task_enable_random_interval_switch.change(
         fn=lambda x: save_time_interval_settings(task_enable_random_interval=x),
-        inputs=[task_enable_random_interval_checkbox],
+        inputs=[task_enable_random_interval_switch],
         outputs=[],
     )
     min_task_delay_slider_minutes.change(

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -360,6 +360,84 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 interactive=True,
             )
 
+        # --- Step Delay Settings ---
+        with gr.Row():
+            step_enable_random_interval = get_env_value("STEP_ENABLE_RANDOM_INTERVAL", False, bool)
+            step_enable_random_interval_checkbox = gr.Checkbox(
+                label="Enable Random Interval for Step Delay",
+                value=step_enable_random_interval,
+                interactive=True,
+            )
+        with gr.Row():
+            min_step_delay_slider_minutes = gr.Slider(
+                label="Min Step Delay (minutes)",
+                minimum=0,
+                maximum=1440,
+                value=get_env_value("STEP_MIN_DELAY_MINUTES", 0.0, float),
+                step=1,
+                interactive=step_enable_random_interval,
+            )
+            max_step_delay_slider_minutes = gr.Slider(
+                label="Max Step Delay (minutes)",
+                minimum=0,
+                maximum=1440,
+                value=get_env_value("STEP_MAX_DELAY_MINUTES", 0.0, float),
+                step=1,
+                interactive=step_enable_random_interval,
+            )
+
+        # --- Action Delay Settings ---
+        with gr.Row():
+            action_enable_random_interval = get_env_value("ACTION_ENABLE_RANDOM_INTERVAL", False, bool)
+            action_enable_random_interval_checkbox = gr.Checkbox(
+                label="Enable Random Interval for Action Delay",
+                value=action_enable_random_interval,
+                interactive=True,
+            )
+        with gr.Row():
+            min_action_delay_slider_minutes = gr.Slider(
+                label="Min Action Delay (minutes)",
+                minimum=0,
+                maximum=1440,
+                value=get_env_value("ACTION_MIN_DELAY_MINUTES", 0.0, float),
+                step=1,
+                interactive=action_enable_random_interval,
+            )
+            max_action_delay_slider_minutes = gr.Slider(
+                label="Max Action Delay (minutes)",
+                minimum=0,
+                maximum=1440,
+                value=get_env_value("ACTION_MAX_DELAY_MINUTES", 0.0, float),
+                step=1,
+                interactive=action_enable_random_interval,
+            )
+
+        # --- Task Delay Settings ---
+        with gr.Row():
+            task_enable_random_interval = get_env_value("TASK_ENABLE_RANDOM_INTERVAL", False, bool)
+            task_enable_random_interval_checkbox = gr.Checkbox(
+                label="Enable Random Interval for Task Delay",
+                value=task_enable_random_interval,
+                interactive=True,
+            )
+        with gr.Row():
+            min_task_delay_slider_minutes = gr.Slider(
+                label="Min Task Delay (minutes)",
+                minimum=0,
+                maximum=1440,
+                value=get_env_value("TASK_MIN_DELAY_MINUTES", 0.0, float),
+                step=1,
+                interactive=task_enable_random_interval,
+            )
+            max_task_delay_slider_minutes = gr.Slider(
+                label="Max Task Delay (minutes)",
+                minimum=0,
+                maximum=1440,
+                value=get_env_value("TASK_MAX_DELAY_MINUTES", 0.0, float),
+                step=1,
+                interactive=task_enable_random_interval,
+            )
+
     tab_components.update(
         dict(
             override_system_prompt=override_system_prompt,
@@ -386,10 +464,19 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             mcp_server_config=mcp_server_config,
             step_delay_minutes=step_delay_slider_minutes,
             custom_step_delay_minutes=custom_step_delay_minutes,
+            step_enable_random_interval=step_enable_random_interval_checkbox,
+            min_step_delay_minutes=min_step_delay_slider_minutes,
+            max_step_delay_minutes=max_step_delay_slider_minutes,
             action_delay_minutes=action_delay_slider_minutes,
             custom_action_delay_minutes=custom_action_delay_minutes,
+            action_enable_random_interval=action_enable_random_interval_checkbox,
+            min_action_delay_minutes=min_action_delay_slider_minutes,
+            max_action_delay_minutes=max_action_delay_slider_minutes,
             task_delay_minutes=task_delay_slider_minutes,
             custom_task_delay_minutes=custom_task_delay_minutes,
+            task_enable_random_interval=task_enable_random_interval_checkbox,
+            min_task_delay_minutes=min_task_delay_slider_minutes,
+            max_task_delay_minutes=max_task_delay_slider_minutes,
         )
     )
     webui_manager.add_components("agent_settings", tab_components)
@@ -459,15 +546,44 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
     # Add a new function to save time interval settings
     def save_time_interval_settings(
-        step_delay_minutes=None, action_delay_minutes=None, task_delay_minutes=None
+        step_delay_minutes=None, action_delay_minutes=None, task_delay_minutes=None,
+        step_enable_random_interval=None, min_step_delay_minutes=None, max_step_delay_minutes=None,
+        action_enable_random_interval=None, min_action_delay_minutes=None, max_action_delay_minutes=None,
+        task_enable_random_interval=None, min_task_delay_minutes=None, max_task_delay_minutes=None
     ):
         env_vars = webui_manager.load_env_settings()
+        # Fixed delays
         if step_delay_minutes is not None:
             env_vars["STEP_DELAY_MINUTES"] = str(step_delay_minutes)
         if action_delay_minutes is not None:
             env_vars["ACTION_DELAY_MINUTES"] = str(action_delay_minutes)
         if task_delay_minutes is not None:
             env_vars["TASK_DELAY_MINUTES"] = str(task_delay_minutes)
+
+        # Step random interval settings
+        if step_enable_random_interval is not None:
+            env_vars["STEP_ENABLE_RANDOM_INTERVAL"] = str(step_enable_random_interval).lower()
+        if min_step_delay_minutes is not None:
+            env_vars["STEP_MIN_DELAY_MINUTES"] = str(min_step_delay_minutes)
+        if max_step_delay_minutes is not None:
+            env_vars["STEP_MAX_DELAY_MINUTES"] = str(max_step_delay_minutes)
+
+        # Action random interval settings
+        if action_enable_random_interval is not None:
+            env_vars["ACTION_ENABLE_RANDOM_INTERVAL"] = str(action_enable_random_interval).lower()
+        if min_action_delay_minutes is not None:
+            env_vars["ACTION_MIN_DELAY_MINUTES"] = str(min_action_delay_minutes)
+        if max_action_delay_minutes is not None:
+            env_vars["ACTION_MAX_DELAY_MINUTES"] = str(max_action_delay_minutes)
+
+        # Task random interval settings
+        if task_enable_random_interval is not None:
+            env_vars["TASK_ENABLE_RANDOM_INTERVAL"] = str(task_enable_random_interval).lower()
+        if min_task_delay_minutes is not None:
+            env_vars["TASK_MIN_DELAY_MINUTES"] = str(min_task_delay_minutes)
+        if max_task_delay_minutes is not None:
+            env_vars["TASK_MAX_DELAY_MINUTES"] = str(max_task_delay_minutes)
+
         webui_manager.save_env_settings(env_vars)
 
     # Connect change events to auto-save functions
@@ -550,6 +666,109 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         custom_task_delay_minutes,
         'task_delay_minutes',
         save_time_interval_settings
+    )
+
+    # --- Define interactivity update logic ---
+    def update_delay_interactivity(checkbox_state):
+        # If checkbox is True (random interval enabled):
+        # - Min/Max sliders are interactive
+        # - Fixed delay inputs are NOT interactive
+        # If checkbox is False (random interval disabled):
+        # - Min/Max sliders are NOT interactive
+        # - Fixed delay inputs are interactive
+        return [
+            gr.update(interactive=checkbox_state),  # For min_slider
+            gr.update(interactive=checkbox_state),  # For max_slider
+            gr.update(interactive=not checkbox_state),  # For fixed_delay_number_input
+            gr.update(interactive=not checkbox_state),  # For fixed_delay_descriptive_slider
+        ]
+
+    # --- Connect interactivity logic for Step Delay ---
+    step_enable_random_interval_checkbox.change(
+        fn=update_delay_interactivity,
+        inputs=[step_enable_random_interval_checkbox],
+        outputs=[
+            min_step_delay_slider_minutes,
+            max_step_delay_slider_minutes,
+            custom_step_delay_minutes,
+            step_delay_slider_minutes,
+        ],
+    )
+
+    # --- Connect interactivity logic for Action Delay ---
+    action_enable_random_interval_checkbox.change(
+        fn=update_delay_interactivity,
+        inputs=[action_enable_random_interval_checkbox],
+        outputs=[
+            min_action_delay_slider_minutes,
+            max_action_delay_slider_minutes,
+            custom_action_delay_minutes,
+            action_delay_slider_minutes,
+        ],
+    )
+
+    # --- Connect interactivity logic for Task Delay ---
+    task_enable_random_interval_checkbox.change(
+        fn=update_delay_interactivity,
+        inputs=[task_enable_random_interval_checkbox],
+        outputs=[
+            min_task_delay_slider_minutes,
+            max_task_delay_slider_minutes,
+            custom_task_delay_minutes,
+            task_delay_slider_minutes,
+        ],
+    )
+
+    # --- Connect save logic for new interval components ---
+    # Step delay random interval
+    step_enable_random_interval_checkbox.change(
+        fn=lambda x: save_time_interval_settings(step_enable_random_interval=x),
+        inputs=[step_enable_random_interval_checkbox],
+        outputs=[],
+    )
+    min_step_delay_slider_minutes.change(
+        fn=lambda x: save_time_interval_settings(min_step_delay_minutes=x),
+        inputs=[min_step_delay_slider_minutes],
+        outputs=[],
+    )
+    max_step_delay_slider_minutes.change(
+        fn=lambda x: save_time_interval_settings(max_step_delay_minutes=x),
+        inputs=[max_step_delay_slider_minutes],
+        outputs=[],
+    )
+
+    # Action delay random interval
+    action_enable_random_interval_checkbox.change(
+        fn=lambda x: save_time_interval_settings(action_enable_random_interval=x),
+        inputs=[action_enable_random_interval_checkbox],
+        outputs=[],
+    )
+    min_action_delay_slider_minutes.change(
+        fn=lambda x: save_time_interval_settings(min_action_delay_minutes=x),
+        inputs=[min_action_delay_slider_minutes],
+        outputs=[],
+    )
+    max_action_delay_slider_minutes.change(
+        fn=lambda x: save_time_interval_settings(max_action_delay_minutes=x),
+        inputs=[max_action_delay_slider_minutes],
+        outputs=[],
+    )
+
+    # Task delay random interval
+    task_enable_random_interval_checkbox.change(
+        fn=lambda x: save_time_interval_settings(task_enable_random_interval=x),
+        inputs=[task_enable_random_interval_checkbox],
+        outputs=[],
+    )
+    min_task_delay_slider_minutes.change(
+        fn=lambda x: save_time_interval_settings(min_task_delay_minutes=x),
+        inputs=[min_task_delay_slider_minutes],
+        outputs=[],
+    )
+    max_task_delay_slider_minutes.change(
+        fn=lambda x: save_time_interval_settings(max_task_delay_minutes=x),
+        inputs=[max_task_delay_slider_minutes],
+        outputs=[],
     )
 
     return list(tab_components.values())

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -136,7 +136,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 interactive=True,
             )
 
-            initial_llm_model_choices = config.model_names.get(str(initial_llm_provider), [])
+            initial_llm_model_choices = config.model_names.get(
+                str(initial_llm_provider), []
+            )
             initial_llm_model_name = get_env_value(
                 "LLM_MODEL_NAME",
                 initial_llm_model_choices[0] if initial_llm_model_choices else "gpt-4o",
@@ -182,7 +184,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         with gr.Row():
             llm_base_url = gr.Textbox(
                 label="Base URL",
-                value=get_env_value(f"{str(initial_llm_provider).upper()}_ENDPOINT", ""),
+                value=get_env_value(
+                    f"{str(initial_llm_provider).upper()}_ENDPOINT", ""
+                ),
                 info="API endpoint URL (if required)",
             )
             llm_api_key = gr.Textbox(
@@ -204,7 +208,12 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             )
 
             initial_planner_model_choices = (
-                config.model_names.get(str(initial_planner_llm_provider) if initial_planner_llm_provider else "", [])
+                config.model_names.get(
+                    str(initial_planner_llm_provider)
+                    if initial_planner_llm_provider
+                    else "",
+                    [],
+                )
                 if initial_planner_llm_provider
                 else []
             )
@@ -256,7 +265,10 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             planner_llm_base_url = gr.Textbox(
                 label="Base URL",
                 value=get_env_value(
-                    f"{str(initial_planner_llm_provider).upper()}_ENDPOINT" if initial_planner_llm_provider else "", ""
+                    f"{str(initial_planner_llm_provider).upper()}_ENDPOINT"
+                    if initial_planner_llm_provider
+                    else "",
+                    "",
                 )
                 if initial_planner_llm_provider
                 else "",
@@ -266,7 +278,10 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 label="API Key",
                 type="password",
                 value=get_env_value(
-                    f"{str(initial_planner_llm_provider).upper()}_API_KEY" if initial_planner_llm_provider else "", ""
+                    f"{str(initial_planner_llm_provider).upper()}_API_KEY"
+                    if initial_planner_llm_provider
+                    else "",
+                    "",
                 )
                 if initial_planner_llm_provider
                 else "",
@@ -309,137 +324,264 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             visible=True,
         )
 
+    # Improved Delay Settings UI
     with gr.Group():
-        with gr.Row():
-            step_delay_slider_minutes = gr.Slider(
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("STEP_DELAY_MINUTES", 0.0, float),
-                step=1,
-                label="Delay Between Steps (minutes)",
-                info="Time to wait in minutes (0-1440) before executing each agent step.",
-                interactive=True,
-            )
-            custom_step_delay_minutes = gr.Number(
-                label="Custom Step Delay (mins)",
-                value=get_env_value("STEP_DELAY_MINUTES", 0.0, float),
-                minimum=0,
-                maximum=1440,
-                interactive=True,
-            )
-            action_delay_slider_minutes = gr.Slider(
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("ACTION_DELAY_MINUTES", 0.0, float),
-                step=1,
-                label="Delay Between Actions (minutes)",
-                info="Time to wait in minutes (0-1440) between individual actions (if applicable; currently may not be supported by all agent bases).",
-                interactive=True,
-            )
-            custom_action_delay_minutes = gr.Number(
-                label="Custom Action Delay (mins)",
-                value=get_env_value("ACTION_DELAY_MINUTES", 0.0, float),
-                minimum=0,
-                maximum=1440,
-                interactive=True,
-            )
-            task_delay_slider_minutes = gr.Slider(
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("TASK_DELAY_MINUTES", 0.0, float),
-                step=1,
-                label="Delay Between Tasks (minutes)",
-                info="Time to wait in minutes (0-1440) before starting a new task or run (interpretation may vary based on execution context).",
-                interactive=True,
-            )
-            custom_task_delay_minutes = gr.Number(
-                label="Custom Task Delay (mins)",
-                value=get_env_value("TASK_DELAY_MINUTES", 0.0, float),
-                minimum=0,
-                maximum=1440,
-                interactive=True,
-            )
+        gr.Markdown("## ⏱️ Agent Timing & Delays")
+        gr.Markdown(
+            "Configure delays between agent operations to control execution speed and avoid rate limits."
+        )
 
-        # --- Step Delay Settings ---
-        with gr.Row():
-            step_enable_random_interval = get_env_value("STEP_ENABLE_RANDOM_INTERVAL", False, bool)
-            step_enable_random_interval_switch = gr.Checkbox(
-                label="🎲 Random Interval for Step Delay",
-                value=step_enable_random_interval,
-                interactive=True,
-                elem_classes=["switch-checkbox"]
-            )
-        with gr.Row(visible=step_enable_random_interval) as step_interval_row:
-            min_step_delay_slider_minutes = gr.Slider(
-                label="Min Step Delay (minutes)",
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("STEP_MIN_DELAY_MINUTES", 0.0, float),
-                step=1,
-                interactive=True,
-            )
-            max_step_delay_slider_minutes = gr.Slider(
-                label="Max Step Delay (minutes)",
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("STEP_MAX_DELAY_MINUTES", 0.0, float),
-                step=1,
-                interactive=True,
-            )
+        with gr.Tabs():
+            # Step Delays Tab
+            with gr.Tab("🚶 Step Delays"):
+                gr.Markdown(
+                    "**Step delays** occur before each agent reasoning step (between thinking phases)"
+                )
 
-        # --- Action Delay Settings ---
-        with gr.Row():
-            action_enable_random_interval = get_env_value("ACTION_ENABLE_RANDOM_INTERVAL", False, bool)
-            action_enable_random_interval_switch = gr.Checkbox(
-                label="🎲 Random Interval for Action Delay",
-                value=action_enable_random_interval,
-                interactive=True,
-                elem_classes=["switch-checkbox"]
-            )
-        with gr.Row(visible=action_enable_random_interval) as action_interval_row:
-            min_action_delay_slider_minutes = gr.Slider(
-                label="Min Action Delay (minutes)",
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("ACTION_MIN_DELAY_MINUTES", 0.0, float),
-                step=1,
-                interactive=True,
-            )
-            max_action_delay_slider_minutes = gr.Slider(
-                label="Max Action Delay (minutes)",
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("ACTION_MAX_DELAY_MINUTES", 0.0, float),
-                step=1,
-                interactive=True,
-            )
+                with gr.Row():
+                    step_delay_preset = gr.Dropdown(
+                        label="Quick Presets",
+                        choices=[
+                            ("No delay", "0"),
+                            ("Fast (30s)", "0.5"),
+                            ("Normal (2min)", "2"),
+                            ("Slow (5min)", "5"),
+                            ("Very slow (10min)", "10"),
+                            ("Custom", "custom"),
+                        ],
+                        value="0",
+                        interactive=True,
+                        info="Choose a preset or select 'Custom' for manual configuration",
+                    )
 
-        # --- Task Delay Settings ---
-        with gr.Row():
-            task_enable_random_interval = get_env_value("TASK_ENABLE_RANDOM_INTERVAL", False, bool)
-            task_enable_random_interval_switch = gr.Checkbox(
-                label="🎲 Random Interval for Task Delay",
-                value=task_enable_random_interval,
-                interactive=True,
-                elem_classes=["switch-checkbox"]
-            )
-        with gr.Row(visible=task_enable_random_interval) as task_interval_row:
-            min_task_delay_slider_minutes = gr.Slider(
-                label="Min Task Delay (minutes)",
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("TASK_MIN_DELAY_MINUTES", 0.0, float),
-                step=1,
-                interactive=True,
-            )
-            max_task_delay_slider_minutes = gr.Slider(
-                label="Max Task Delay (minutes)",
-                minimum=0,
-                maximum=1440,
-                value=get_env_value("TASK_MAX_DELAY_MINUTES", 0.0, float),
-                step=1,
-                interactive=True,
-            )
+                with gr.Row():
+                    step_enable_random_interval_switch = gr.Checkbox(
+                        label="🎲 Enable Random Intervals",
+                        value=get_env_value("STEP_ENABLE_RANDOM_INTERVAL", False, bool),
+                        interactive=True,
+                        info="Use random delays instead of fixed delays",
+                    )
+
+                with gr.Group() as step_fixed_group:
+                    with gr.Row():
+                        step_delay_value = gr.Number(
+                            label="Step Delay",
+                            value=get_env_value("STEP_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        step_delay_unit = gr.Dropdown(
+                            label="Unit",
+                            choices=[
+                                ("Seconds", "seconds"),
+                                ("Minutes", "minutes"),
+                                ("Hours", "hours"),
+                            ],
+                            value="minutes",
+                            interactive=True,
+                        )
+
+                with gr.Group(
+                    visible=get_env_value("STEP_ENABLE_RANDOM_INTERVAL", False, bool)
+                ) as step_random_group:
+                    gr.Markdown("**Random Interval Range:**")
+                    with gr.Row():
+                        step_min_delay = gr.Number(
+                            label="Minimum Delay",
+                            value=get_env_value("STEP_MIN_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        step_max_delay = gr.Number(
+                            label="Maximum Delay",
+                            value=get_env_value("STEP_MAX_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        step_random_unit = gr.Dropdown(
+                            label="Unit",
+                            choices=[
+                                ("Seconds", "seconds"),
+                                ("Minutes", "minutes"),
+                                ("Hours", "hours"),
+                            ],
+                            value="minutes",
+                            interactive=True,
+                        )
+
+            # Action Delays Tab
+            with gr.Tab("⚡ Action Delays"):
+                gr.Markdown(
+                    "**Action delays** occur between individual browser actions within a single step"
+                )
+
+                with gr.Row():
+                    action_delay_preset = gr.Dropdown(
+                        label="Quick Presets",
+                        choices=[
+                            ("No delay", "0"),
+                            ("Fast (5s)", "0.083"),
+                            ("Normal (30s)", "0.5"),
+                            ("Slow (1min)", "1"),
+                            ("Very slow (2min)", "2"),
+                            ("Custom", "custom"),
+                        ],
+                        value="0",
+                        interactive=True,
+                        info="Choose a preset or select 'Custom' for manual configuration",
+                    )
+
+                with gr.Row():
+                    action_enable_random_interval_switch = gr.Checkbox(
+                        label="🎲 Enable Random Intervals",
+                        value=get_env_value(
+                            "ACTION_ENABLE_RANDOM_INTERVAL", False, bool
+                        ),
+                        interactive=True,
+                        info="Use random delays instead of fixed delays",
+                    )
+
+                with gr.Group() as action_fixed_group:
+                    with gr.Row():
+                        action_delay_value = gr.Number(
+                            label="Action Delay",
+                            value=get_env_value("ACTION_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        action_delay_unit = gr.Dropdown(
+                            label="Unit",
+                            choices=[
+                                ("Seconds", "seconds"),
+                                ("Minutes", "minutes"),
+                                ("Hours", "hours"),
+                            ],
+                            value="minutes",
+                            interactive=True,
+                        )
+
+                with gr.Group(
+                    visible=get_env_value("ACTION_ENABLE_RANDOM_INTERVAL", False, bool)
+                ) as action_random_group:
+                    gr.Markdown("**Random Interval Range:**")
+                    with gr.Row():
+                        action_min_delay = gr.Number(
+                            label="Minimum Delay",
+                            value=get_env_value("ACTION_MIN_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        action_max_delay = gr.Number(
+                            label="Maximum Delay",
+                            value=get_env_value("ACTION_MAX_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        action_random_unit = gr.Dropdown(
+                            label="Unit",
+                            choices=[
+                                ("Seconds", "seconds"),
+                                ("Minutes", "minutes"),
+                                ("Hours", "hours"),
+                            ],
+                            value="minutes",
+                            interactive=True,
+                        )
+
+            # Task Delays Tab
+            with gr.Tab("📋 Task Delays"):
+                gr.Markdown(
+                    "**Task delays** occur at the beginning of each new task/run"
+                )
+
+                with gr.Row():
+                    task_delay_preset = gr.Dropdown(
+                        label="Quick Presets",
+                        choices=[
+                            ("No delay", "0"),
+                            ("Fast (1min)", "1"),
+                            ("Normal (5min)", "5"),
+                            ("Slow (15min)", "15"),
+                            ("Very slow (30min)", "30"),
+                            ("Custom", "custom"),
+                        ],
+                        value="0",
+                        interactive=True,
+                        info="Choose a preset or select 'Custom' for manual configuration",
+                    )
+
+                with gr.Row():
+                    task_enable_random_interval_switch = gr.Checkbox(
+                        label="🎲 Enable Random Intervals",
+                        value=get_env_value("TASK_ENABLE_RANDOM_INTERVAL", False, bool),
+                        interactive=True,
+                        info="Use random delays instead of fixed delays",
+                    )
+
+                with gr.Group() as task_fixed_group:
+                    with gr.Row():
+                        task_delay_value = gr.Number(
+                            label="Task Delay",
+                            value=get_env_value("TASK_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        task_delay_unit = gr.Dropdown(
+                            label="Unit",
+                            choices=[
+                                ("Seconds", "seconds"),
+                                ("Minutes", "minutes"),
+                                ("Hours", "hours"),
+                            ],
+                            value="minutes",
+                            interactive=True,
+                        )
+
+                with gr.Group(
+                    visible=get_env_value("TASK_ENABLE_RANDOM_INTERVAL", False, bool)
+                ) as task_random_group:
+                    gr.Markdown("**Random Interval Range:**")
+                    with gr.Row():
+                        task_min_delay = gr.Number(
+                            label="Minimum Delay",
+                            value=get_env_value("TASK_MIN_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        task_max_delay = gr.Number(
+                            label="Maximum Delay",
+                            value=get_env_value("TASK_MAX_DELAY_MINUTES", 0.0, float),
+                            minimum=0,
+                            maximum=1440,
+                            interactive=True,
+                            precision=2,
+                        )
+                        task_random_unit = gr.Dropdown(
+                            label="Unit",
+                            choices=[
+                                ("Seconds", "seconds"),
+                                ("Minutes", "minutes"),
+                                ("Hours", "hours"),
+                            ],
+                            value="minutes",
+                            interactive=True,
+                        )
 
     tab_components.update(
         dict(
@@ -465,21 +607,28 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             tool_calling_method=tool_calling_method,
             mcp_json_file=mcp_json_file,
             mcp_server_config=mcp_server_config,
-            step_delay_minutes=step_delay_slider_minutes,
-            custom_step_delay_minutes=custom_step_delay_minutes,
+            # New delay components
+            step_delay_preset=step_delay_preset,
+            step_delay_value=step_delay_value,
+            step_delay_unit=step_delay_unit,
             step_enable_random_interval=step_enable_random_interval_switch,
-            min_step_delay_minutes=min_step_delay_slider_minutes,
-            max_step_delay_minutes=max_step_delay_slider_minutes,
-            action_delay_minutes=action_delay_slider_minutes,
-            custom_action_delay_minutes=custom_action_delay_minutes,
+            step_min_delay=step_min_delay,
+            step_max_delay=step_max_delay,
+            step_random_unit=step_random_unit,
+            action_delay_preset=action_delay_preset,
+            action_delay_value=action_delay_value,
+            action_delay_unit=action_delay_unit,
             action_enable_random_interval=action_enable_random_interval_switch,
-            min_action_delay_minutes=min_action_delay_slider_minutes,
-            max_action_delay_minutes=max_action_delay_slider_minutes,
-            task_delay_minutes=task_delay_slider_minutes,
-            custom_task_delay_minutes=custom_task_delay_minutes,
+            action_min_delay=action_min_delay,
+            action_max_delay=action_max_delay,
+            action_random_unit=action_random_unit,
+            task_delay_preset=task_delay_preset,
+            task_delay_value=task_delay_value,
+            task_delay_unit=task_delay_unit,
             task_enable_random_interval=task_enable_random_interval_switch,
-            min_task_delay_minutes=min_task_delay_slider_minutes,
-            max_task_delay_minutes=max_task_delay_slider_minutes,
+            task_min_delay=task_min_delay,
+            task_max_delay=task_max_delay,
+            task_random_unit=task_random_unit,
         )
     )
     webui_manager.add_components("agent_settings", tab_components)
@@ -549,10 +698,18 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
     # Add a new function to save time interval settings
     def save_time_interval_settings(
-        step_delay_minutes=None, action_delay_minutes=None, task_delay_minutes=None,
-        step_enable_random_interval=None, min_step_delay_minutes=None, max_step_delay_minutes=None,
-        action_enable_random_interval=None, min_action_delay_minutes=None, max_action_delay_minutes=None,
-        task_enable_random_interval=None, min_task_delay_minutes=None, max_task_delay_minutes=None
+        step_delay_minutes=None,
+        action_delay_minutes=None,
+        task_delay_minutes=None,
+        step_enable_random_interval=None,
+        min_step_delay_minutes=None,
+        max_step_delay_minutes=None,
+        action_enable_random_interval=None,
+        min_action_delay_minutes=None,
+        max_action_delay_minutes=None,
+        task_enable_random_interval=None,
+        min_task_delay_minutes=None,
+        max_task_delay_minutes=None,
     ):
         env_vars = webui_manager.load_env_settings()
         # Fixed delays
@@ -565,7 +722,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
         # Step random interval settings
         if step_enable_random_interval is not None:
-            env_vars["STEP_ENABLE_RANDOM_INTERVAL"] = str(step_enable_random_interval).lower()
+            env_vars["STEP_ENABLE_RANDOM_INTERVAL"] = str(
+                step_enable_random_interval
+            ).lower()
         if min_step_delay_minutes is not None:
             env_vars["STEP_MIN_DELAY_MINUTES"] = str(min_step_delay_minutes)
         if max_step_delay_minutes is not None:
@@ -573,7 +732,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
         # Action random interval settings
         if action_enable_random_interval is not None:
-            env_vars["ACTION_ENABLE_RANDOM_INTERVAL"] = str(action_enable_random_interval).lower()
+            env_vars["ACTION_ENABLE_RANDOM_INTERVAL"] = str(
+                action_enable_random_interval
+            ).lower()
         if min_action_delay_minutes is not None:
             env_vars["ACTION_MIN_DELAY_MINUTES"] = str(min_action_delay_minutes)
         if max_action_delay_minutes is not None:
@@ -581,7 +742,9 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
         # Task random interval settings
         if task_enable_random_interval is not None:
-            env_vars["TASK_ENABLE_RANDOM_INTERVAL"] = str(task_enable_random_interval).lower()
+            env_vars["TASK_ENABLE_RANDOM_INTERVAL"] = str(
+                task_enable_random_interval
+            ).lower()
         if min_task_delay_minutes is not None:
             env_vars["TASK_MIN_DELAY_MINUTES"] = str(min_task_delay_minutes)
         if max_task_delay_minutes is not None:
@@ -589,10 +752,114 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
 
         webui_manager.save_env_settings(env_vars)
 
+    # Add a new function to save main LLM settings
+    def save_main_llm_settings(
+        model_name=None,
+        temperature=None,
+        use_vision=None,
+        ollama_num_ctx=None,
+        max_steps=None,
+        max_actions=None,
+        max_input_tokens=None,
+        tool_calling_method=None,
+        override_system_prompt=None,
+        extend_system_prompt=None,
+    ):
+        env_vars = webui_manager.load_env_settings()
+        if model_name is not None:
+            env_vars["LLM_MODEL_NAME"] = str(model_name)
+        if temperature is not None:
+            env_vars["LLM_TEMPERATURE"] = str(temperature)
+        if use_vision is not None:
+            env_vars["USE_VISION"] = str(use_vision).lower()
+        if ollama_num_ctx is not None:
+            env_vars["OLLAMA_NUM_CTX"] = str(ollama_num_ctx)
+        if max_steps is not None:
+            env_vars["MAX_STEPS"] = str(max_steps)
+        if max_actions is not None:
+            env_vars["MAX_ACTIONS"] = str(max_actions)
+        if max_input_tokens is not None:
+            env_vars["MAX_INPUT_TOKENS"] = str(max_input_tokens)
+        if tool_calling_method is not None:
+            env_vars["TOOL_CALLING_METHOD"] = str(tool_calling_method)
+        if override_system_prompt is not None:
+            env_vars["OVERRIDE_SYSTEM_PROMPT"] = str(override_system_prompt)
+        if extend_system_prompt is not None:
+            env_vars["EXTEND_SYSTEM_PROMPT"] = str(extend_system_prompt)
+        webui_manager.save_env_settings(env_vars)
+
     # Connect change events to auto-save functions
     llm_provider.change(
         fn=lambda provider: save_llm_api_setting(provider=provider),
         inputs=[llm_provider],
+        outputs=[],
+    )
+
+    llm_model_name.change(
+        fn=lambda model_name: save_main_llm_settings(model_name=model_name),
+        inputs=[llm_model_name],
+        outputs=[],
+    )
+
+    llm_temperature.change(
+        fn=lambda temperature: save_main_llm_settings(temperature=temperature),
+        inputs=[llm_temperature],
+        outputs=[],
+    )
+
+    use_vision.change(
+        fn=lambda use_vision: save_main_llm_settings(use_vision=use_vision),
+        inputs=[use_vision],
+        outputs=[],
+    )
+
+    ollama_num_ctx.change(
+        fn=lambda ollama_num_ctx: save_main_llm_settings(ollama_num_ctx=ollama_num_ctx),
+        inputs=[ollama_num_ctx],
+        outputs=[],
+    )
+
+    max_steps.change(
+        fn=lambda max_steps: save_main_llm_settings(max_steps=max_steps),
+        inputs=[max_steps],
+        outputs=[],
+    )
+
+    max_actions.change(
+        fn=lambda max_actions: save_main_llm_settings(max_actions=max_actions),
+        inputs=[max_actions],
+        outputs=[],
+    )
+
+    max_input_tokens.change(
+        fn=lambda max_input_tokens: save_main_llm_settings(
+            max_input_tokens=max_input_tokens
+        ),
+        inputs=[max_input_tokens],
+        outputs=[],
+    )
+
+    tool_calling_method.change(
+        fn=lambda tool_calling_method: save_main_llm_settings(
+            tool_calling_method=tool_calling_method
+        ),
+        inputs=[tool_calling_method],
+        outputs=[],
+    )
+
+    override_system_prompt.change(
+        fn=lambda override_system_prompt: save_main_llm_settings(
+            override_system_prompt=override_system_prompt
+        ),
+        inputs=[override_system_prompt],
+        outputs=[],
+    )
+
+    extend_system_prompt.change(
+        fn=lambda extend_system_prompt: save_main_llm_settings(
+            extend_system_prompt=extend_system_prompt
+        ),
+        inputs=[extend_system_prompt],
         outputs=[],
     )
 
@@ -651,122 +918,211 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         outputs=[],
     )
 
-    # Setup synchronized delay settings using the helper function
-    setup_synchronized_delay_setting(
-        step_delay_slider_minutes,
-        custom_step_delay_minutes,
-        'step_delay_minutes',
-        save_time_interval_settings
-    )
-    setup_synchronized_delay_setting(
-        action_delay_slider_minutes,
-        custom_action_delay_minutes,
-        'action_delay_minutes',
-        save_time_interval_settings
-    )
-    setup_synchronized_delay_setting(
-        task_delay_slider_minutes,
-        custom_task_delay_minutes,
-        'task_delay_minutes',
-        save_time_interval_settings
-    )
+    # Helper functions for the new delay UI
+    def convert_to_minutes(value, unit):
+        """Convert delay value to minutes based on unit"""
+        if unit == "seconds":
+            return value / 60
+        elif unit == "hours":
+            return value * 60
+        else:  # minutes
+            return value
 
-    # --- Define visibility and interactivity update logic ---
-    def update_delay_interactivity(switch_state):
-        # If switch is True (random interval enabled):
-        # - Interval row is visible and interactive
-        # - Fixed delay inputs are NOT interactive
-        # If switch is False (random interval disabled):
-        # - Interval row is hidden
-        # - Fixed delay inputs are interactive
+    def apply_preset(preset_value, delay_type):
+        """Apply preset delay value"""
+        if preset_value == "custom":
+            return gr.update(), gr.update(interactive=True)
+        else:
+            minutes = float(preset_value)
+            return gr.update(value=minutes), gr.update(interactive=False)
+
+    def toggle_random_mode(enable_random, delay_type):
+        """Toggle between fixed and random delay modes"""
         return [
-            gr.update(visible=switch_state),  # For interval row
-            gr.update(interactive=not switch_state),  # For fixed_delay_number_input
-            gr.update(interactive=not switch_state),  # For fixed_delay_descriptive_slider
+            gr.update(visible=not enable_random),  # fixed group
+            gr.update(visible=enable_random),  # random group
         ]
 
-    # --- Connect visibility logic for Step Delay ---
+    def save_delay_setting(
+        delay_type,
+        value=None,
+        unit=None,
+        enable_random=None,
+        min_delay=None,
+        max_delay=None,
+        random_unit=None,
+    ):
+        """Save delay settings to environment"""
+        env_vars = webui_manager.load_env_settings()
+
+        if enable_random is not None:
+            env_vars[f"{delay_type.upper()}_ENABLE_RANDOM_INTERVAL"] = str(
+                enable_random
+            ).lower()
+
+        if value is not None and unit is not None:
+            minutes = convert_to_minutes(value, unit)
+            env_vars[f"{delay_type.upper()}_DELAY_MINUTES"] = str(minutes)
+
+        if min_delay is not None and random_unit is not None:
+            min_minutes = convert_to_minutes(min_delay, random_unit)
+            env_vars[f"{delay_type.upper()}_MIN_DELAY_MINUTES"] = str(min_minutes)
+
+        if max_delay is not None and random_unit is not None:
+            max_minutes = convert_to_minutes(max_delay, random_unit)
+            env_vars[f"{delay_type.upper()}_MAX_DELAY_MINUTES"] = str(max_minutes)
+
+        webui_manager.save_env_settings(env_vars)
+
+    # Connect preset dropdowns
+    step_delay_preset.change(
+        fn=lambda preset: apply_preset(preset, "step"),
+        inputs=[step_delay_preset],
+        outputs=[step_delay_value, step_delay_value],
+    )
+    action_delay_preset.change(
+        fn=lambda preset: apply_preset(preset, "action"),
+        inputs=[action_delay_preset],
+        outputs=[action_delay_value, action_delay_value],
+    )
+    task_delay_preset.change(
+        fn=lambda preset: apply_preset(preset, "task"),
+        inputs=[task_delay_preset],
+        outputs=[task_delay_value, task_delay_value],
+    )
+
+    # Connect random mode toggles
     step_enable_random_interval_switch.change(
-        fn=update_delay_interactivity,
+        fn=lambda enable: toggle_random_mode(enable, "step"),
         inputs=[step_enable_random_interval_switch],
-        outputs=[
-            step_interval_row,
-            custom_step_delay_minutes,
-            step_delay_slider_minutes,
-        ],
+        outputs=[step_fixed_group, step_random_group],
     )
-
-    # --- Connect visibility logic for Action Delay ---
     action_enable_random_interval_switch.change(
-        fn=update_delay_interactivity,
+        fn=lambda enable: toggle_random_mode(enable, "action"),
         inputs=[action_enable_random_interval_switch],
-        outputs=[
-            action_interval_row,
-            custom_action_delay_minutes,
-            action_delay_slider_minutes,
-        ],
+        outputs=[action_fixed_group, action_random_group],
     )
-
-    # --- Connect visibility logic for Task Delay ---
     task_enable_random_interval_switch.change(
-        fn=update_delay_interactivity,
+        fn=lambda enable: toggle_random_mode(enable, "task"),
         inputs=[task_enable_random_interval_switch],
-        outputs=[
-            task_interval_row,
-            custom_task_delay_minutes,
-            task_delay_slider_minutes,
-        ],
+        outputs=[task_fixed_group, task_random_group],
     )
 
-    # --- Connect save logic for new interval components ---
-    # Step delay random interval
+    # Connect auto-save for all delay settings
+    # Step delays
+    step_delay_value.change(
+        fn=lambda value, unit: save_delay_setting("step", value=value, unit=unit),
+        inputs=[step_delay_value, step_delay_unit],
+        outputs=[],
+    )
+    step_delay_unit.change(
+        fn=lambda unit, value: save_delay_setting("step", value=value, unit=unit),
+        inputs=[step_delay_unit, step_delay_value],
+        outputs=[],
+    )
     step_enable_random_interval_switch.change(
-        fn=lambda x: save_time_interval_settings(step_enable_random_interval=x),
+        fn=lambda enable: save_delay_setting("step", enable_random=enable),
         inputs=[step_enable_random_interval_switch],
         outputs=[],
     )
-    min_step_delay_slider_minutes.change(
-        fn=lambda x: save_time_interval_settings(min_step_delay_minutes=x),
-        inputs=[min_step_delay_slider_minutes],
+    step_min_delay.change(
+        fn=lambda min_val, unit: save_delay_setting(
+            "step", min_delay=min_val, random_unit=unit
+        ),
+        inputs=[step_min_delay, step_random_unit],
         outputs=[],
     )
-    max_step_delay_slider_minutes.change(
-        fn=lambda x: save_time_interval_settings(max_step_delay_minutes=x),
-        inputs=[max_step_delay_slider_minutes],
+    step_max_delay.change(
+        fn=lambda max_val, unit: save_delay_setting(
+            "step", max_delay=max_val, random_unit=unit
+        ),
+        inputs=[step_max_delay, step_random_unit],
+        outputs=[],
+    )
+    step_random_unit.change(
+        fn=lambda unit, min_val, max_val: [
+            save_delay_setting("step", min_delay=min_val, random_unit=unit),
+            save_delay_setting("step", max_delay=max_val, random_unit=unit),
+        ],
+        inputs=[step_random_unit, step_min_delay, step_max_delay],
         outputs=[],
     )
 
-    # Action delay random interval
+    # Action delays
+    action_delay_value.change(
+        fn=lambda value, unit: save_delay_setting("action", value=value, unit=unit),
+        inputs=[action_delay_value, action_delay_unit],
+        outputs=[],
+    )
+    action_delay_unit.change(
+        fn=lambda unit, value: save_delay_setting("action", value=value, unit=unit),
+        inputs=[action_delay_unit, action_delay_value],
+        outputs=[],
+    )
     action_enable_random_interval_switch.change(
-        fn=lambda x: save_time_interval_settings(action_enable_random_interval=x),
+        fn=lambda enable: save_delay_setting("action", enable_random=enable),
         inputs=[action_enable_random_interval_switch],
         outputs=[],
     )
-    min_action_delay_slider_minutes.change(
-        fn=lambda x: save_time_interval_settings(min_action_delay_minutes=x),
-        inputs=[min_action_delay_slider_minutes],
+    action_min_delay.change(
+        fn=lambda min_val, unit: save_delay_setting(
+            "action", min_delay=min_val, random_unit=unit
+        ),
+        inputs=[action_min_delay, action_random_unit],
         outputs=[],
     )
-    max_action_delay_slider_minutes.change(
-        fn=lambda x: save_time_interval_settings(max_action_delay_minutes=x),
-        inputs=[max_action_delay_slider_minutes],
+    action_max_delay.change(
+        fn=lambda max_val, unit: save_delay_setting(
+            "action", max_delay=max_val, random_unit=unit
+        ),
+        inputs=[action_max_delay, action_random_unit],
+        outputs=[],
+    )
+    action_random_unit.change(
+        fn=lambda unit, min_val, max_val: [
+            save_delay_setting("action", min_delay=min_val, random_unit=unit),
+            save_delay_setting("action", max_delay=max_val, random_unit=unit),
+        ],
+        inputs=[action_random_unit, action_min_delay, action_max_delay],
         outputs=[],
     )
 
-    # Task delay random interval
+    # Task delays
+    task_delay_value.change(
+        fn=lambda value, unit: save_delay_setting("task", value=value, unit=unit),
+        inputs=[task_delay_value, task_delay_unit],
+        outputs=[],
+    )
+    task_delay_unit.change(
+        fn=lambda unit, value: save_delay_setting("task", value=value, unit=unit),
+        inputs=[task_delay_unit, task_delay_value],
+        outputs=[],
+    )
     task_enable_random_interval_switch.change(
-        fn=lambda x: save_time_interval_settings(task_enable_random_interval=x),
+        fn=lambda enable: save_delay_setting("task", enable_random=enable),
         inputs=[task_enable_random_interval_switch],
         outputs=[],
     )
-    min_task_delay_slider_minutes.change(
-        fn=lambda x: save_time_interval_settings(min_task_delay_minutes=x),
-        inputs=[min_task_delay_slider_minutes],
+    task_min_delay.change(
+        fn=lambda min_val, unit: save_delay_setting(
+            "task", min_delay=min_val, random_unit=unit
+        ),
+        inputs=[task_min_delay, task_random_unit],
         outputs=[],
     )
-    max_task_delay_slider_minutes.change(
-        fn=lambda x: save_time_interval_settings(max_task_delay_minutes=x),
-        inputs=[max_task_delay_slider_minutes],
+    task_max_delay.change(
+        fn=lambda max_val, unit: save_delay_setting(
+            "task", max_delay=max_val, random_unit=unit
+        ),
+        inputs=[task_max_delay, task_random_unit],
+        outputs=[],
+    )
+    task_random_unit.change(
+        fn=lambda unit, min_val, max_val: [
+            save_delay_setting("task", min_delay=min_val, random_unit=unit),
+            save_delay_setting("task", max_delay=max_val, random_unit=unit),
+        ],
+        inputs=[task_random_unit, task_min_delay, task_max_delay],
         outputs=[],
     )
 

--- a/src/webui/components/agent_settings_tab.py
+++ b/src/webui/components/agent_settings_tab.py
@@ -136,7 +136,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 interactive=True,
             )
 
-            initial_llm_model_choices = config.model_names.get(initial_llm_provider, [])
+            initial_llm_model_choices = config.model_names.get(str(initial_llm_provider), [])
             initial_llm_model_name = get_env_value(
                 "LLM_MODEL_NAME",
                 initial_llm_model_choices[0] if initial_llm_model_choices else "gpt-4o",
@@ -182,13 +182,13 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
         with gr.Row():
             llm_base_url = gr.Textbox(
                 label="Base URL",
-                value=get_env_value(f"{initial_llm_provider.upper()}_ENDPOINT", ""),
+                value=get_env_value(f"{str(initial_llm_provider).upper()}_ENDPOINT", ""),
                 info="API endpoint URL (if required)",
             )
             llm_api_key = gr.Textbox(
                 label="API Key",
                 type="password",
-                value=get_env_value(f"{initial_llm_provider.upper()}_API_KEY", ""),
+                value=get_env_value(f"{str(initial_llm_provider).upper()}_API_KEY", ""),
                 info="Your API key (auto-saved to .env)",
             )
 
@@ -204,7 +204,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             )
 
             initial_planner_model_choices = (
-                config.model_names.get(initial_planner_llm_provider, [])
+                config.model_names.get(str(initial_planner_llm_provider) if initial_planner_llm_provider else "", [])
                 if initial_planner_llm_provider
                 else []
             )
@@ -256,7 +256,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
             planner_llm_base_url = gr.Textbox(
                 label="Base URL",
                 value=get_env_value(
-                    f"{initial_planner_llm_provider.upper()}_ENDPOINT", ""
+                    f"{str(initial_planner_llm_provider).upper()}_ENDPOINT" if initial_planner_llm_provider else "", ""
                 )
                 if initial_planner_llm_provider
                 else "",
@@ -266,7 +266,7 @@ def create_agent_settings_tab(webui_manager: WebuiManager):
                 label="API Key",
                 type="password",
                 value=get_env_value(
-                    f"{initial_planner_llm_provider.upper()}_API_KEY", ""
+                    f"{str(initial_planner_llm_provider).upper()}_API_KEY" if initial_planner_llm_provider else "", ""
                 )
                 if initial_planner_llm_provider
                 else "",

--- a/src/webui/components/browser_settings_tab.py
+++ b/src/webui/components/browser_settings_tab.py
@@ -1,13 +1,12 @@
-import os
+import logging
+from typing import Any
 
 import gradio as gr
-import logging
-from gradio.components import Component
 
 from src.webui.webui_manager import WebuiManager
-from src.utils import config
 
 logger = logging.getLogger(__name__)
+
 
 async def close_browser(webui_manager: WebuiManager):
     """
@@ -27,10 +26,25 @@ async def close_browser(webui_manager: WebuiManager):
         await webui_manager.bu_browser.close()
         webui_manager.bu_browser = None
 
+
 def create_browser_settings_tab(webui_manager: WebuiManager):
     """
     Creates a browser settings tab.
     """
+    # Load persistent settings from environment
+    env_settings = webui_manager.load_env_settings()
+
+    def get_env_value(key: str, default: Any, type_cast=None):
+        val = env_settings.get(key, default)
+        if type_cast:
+            try:
+                if type_cast is bool:
+                    return str(val).lower() == "true"
+                return type_cast(val)
+            except (ValueError, TypeError):
+                return default
+        return val
+
     input_components = set(webui_manager.get_components())
     tab_components = {}
 
@@ -40,65 +54,68 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
                 label="Browser Binary Path",
                 lines=1,
                 interactive=True,
-                placeholder="e.g. '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome'"
+                value=get_env_value("BROWSER_PATH", ""),
+                placeholder="e.g. '/Applications/Google\\ Chrome.app/Contents/MacOS/Google\\ Chrome'",
             )
             browser_user_data_dir = gr.Textbox(
                 label="Browser User Data Dir",
                 lines=1,
                 interactive=True,
+                value=get_env_value("BROWSER_USER_DATA", ""),
                 placeholder="Leave it empty if you use your default user data",
             )
     with gr.Group():
         with gr.Row():
             use_own_browser = gr.Checkbox(
                 label="Use Own Browser",
-                value=False,
+                value=get_env_value("USE_OWN_BROWSER", False, bool),
                 info="Use your existing browser instance",
-                interactive=True
+                interactive=True,
             )
             keep_browser_open = gr.Checkbox(
                 label="Keep Browser Open",
-                value=os.getenv("KEEP_BROWSER_OPEN", True),
+                value=get_env_value("KEEP_BROWSER_OPEN", True, bool),
                 info="Keep Browser Open between Tasks",
-                interactive=True
+                interactive=True,
             )
             headless = gr.Checkbox(
                 label="Headless Mode",
-                value=False,
+                value=get_env_value("HEADLESS", False, bool),
                 info="Run browser without GUI",
-                interactive=True
+                interactive=True,
             )
             disable_security = gr.Checkbox(
                 label="Disable Security",
-                value=False,
+                value=get_env_value("DISABLE_SECURITY", False, bool),
                 info="Disable browser security",
-                interactive=True
+                interactive=True,
             )
 
     with gr.Group():
         with gr.Row():
             window_w = gr.Number(
                 label="Window Width",
-                value=1280,
+                value=get_env_value("RESOLUTION_WIDTH", 1280, int),
                 info="Browser window width",
-                interactive=True
+                interactive=True,
             )
             window_h = gr.Number(
                 label="Window Height",
-                value=1100,
+                value=get_env_value("RESOLUTION_HEIGHT", 1100, int),
                 info="Browser window height",
-                interactive=True
+                interactive=True,
             )
     with gr.Group():
         with gr.Row():
             cdp_url = gr.Textbox(
                 label="CDP URL",
-                value=os.getenv("BROWSER_CDP", None),
+                value=get_env_value("BROWSER_CDP", ""),
                 info="CDP URL for browser remote debugging",
                 interactive=True,
             )
             wss_url = gr.Textbox(
                 label="WSS URL",
+                value=get_env_value("WSS_URL", ""),
                 info="WSS URL for browser remote debugging",
                 interactive=True,
             )
@@ -106,6 +123,7 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
         with gr.Row():
             save_recording_path = gr.Textbox(
                 label="Recording Path",
+                value=get_env_value("SAVE_RECORDING_PATH", ""),
                 placeholder="e.g. ./tmp/record_videos",
                 info="Path to save browser recordings",
                 interactive=True,
@@ -113,6 +131,7 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
 
             save_trace_path = gr.Textbox(
                 label="Trace Path",
+                value=get_env_value("SAVE_TRACE_PATH", ""),
                 placeholder="e.g. ./tmp/traces",
                 info="Path to save Agent traces",
                 interactive=True,
@@ -121,13 +140,13 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
         with gr.Row():
             save_agent_history_path = gr.Textbox(
                 label="Agent History Save Path",
-                value="./tmp/agent_history",
+                value=get_env_value("SAVE_AGENT_HISTORY_PATH", "./tmp/agent_history"),
                 info="Specify the directory where agent history should be saved.",
                 interactive=True,
             )
             save_download_path = gr.Textbox(
                 label="Save Directory for browser downloads",
-                value="./tmp/downloads",
+                value=get_env_value("SAVE_DOWNLOAD_PATH", "./tmp/downloads"),
                 info="Specify the directory where downloaded files should be saved.",
                 interactive=True,
             )
@@ -166,83 +185,91 @@ def create_browser_settings_tab(webui_manager: WebuiManager):
 
     # Function to save a single browser setting to .env
     def save_browser_setting(setting_name, setting_value):
-        webui_manager.save_browser_settings_to_env(setting_name=setting_name, setting_value=setting_value)
+        webui_manager.save_browser_settings_to_env(
+            setting_name=setting_name, setting_value=setting_value
+        )
 
     # Connect change events to auto-save function
     browser_binary_path.change(
         fn=lambda value: save_browser_setting("browser_binary_path", value),
         inputs=[browser_binary_path],
-        outputs=[]
+        outputs=[],
     )
 
     browser_user_data_dir.change(
         fn=lambda value: save_browser_setting("browser_user_data_dir", value),
         inputs=[browser_user_data_dir],
-        outputs=[]
+        outputs=[],
+    )
+
+    use_own_browser.change(
+        fn=lambda value: save_browser_setting("use_own_browser", value),
+        inputs=[use_own_browser],
+        outputs=[],
     )
 
     keep_browser_open.change(
         fn=lambda value: save_browser_setting("keep_browser_open", value),
         inputs=[keep_browser_open],
-        outputs=[]
+        outputs=[],
     )
 
     cdp_url.change(
         fn=lambda value: save_browser_setting("cdp_url", value),
         inputs=[cdp_url],
-        outputs=[]
+        outputs=[],
     )
 
     window_w.change(
         fn=lambda value: save_browser_setting("window_w", value),
         inputs=[window_w],
-        outputs=[]
+        outputs=[],
     )
 
     window_h.change(
         fn=lambda value: save_browser_setting("window_h", value),
         inputs=[window_h],
-        outputs=[]
+        outputs=[],
     )
 
     headless.change(
         fn=lambda value: save_browser_setting("headless", value),
         inputs=[headless],
-        outputs=[]
+        outputs=[],
     )
 
     disable_security.change(
         fn=lambda value: save_browser_setting("disable_security", value),
         inputs=[disable_security],
-        outputs=[]
+        outputs=[],
     )
 
     save_recording_path.change(
         fn=lambda value: save_browser_setting("save_recording_path", value),
         inputs=[save_recording_path],
-        outputs=[]
+        outputs=[],
     )
 
     save_trace_path.change(
         fn=lambda value: save_browser_setting("save_trace_path", value),
         inputs=[save_trace_path],
-        outputs=[]
+        outputs=[],
     )
 
     save_agent_history_path.change(
         fn=lambda value: save_browser_setting("save_agent_history_path", value),
         inputs=[save_agent_history_path],
-        outputs=[]
+        outputs=[],
     )
 
     save_download_path.change(
         fn=lambda value: save_browser_setting("save_download_path", value),
         inputs=[save_download_path],
-        outputs=[]
+        outputs=[],
     )
 
     wss_url.change(
         fn=lambda value: save_browser_setting("wss_url", value),
         inputs=[wss_url],
-        outputs=[]
+        outputs=[],
     )


### PR DESCRIPTION
This commit introduces a feature allowing you to configure delays as a random value within a specified interval (min/max) for my operations, initially applied to step delays.

Key changes include:

1.  **UI Enhancements (`src/webui/components/agent_settings_tab.py`):**
    *   For each delay type (step, action, task), the following UI elements
        have been added:
        *   An "Enable Random Interval" checkbox.
        *   "Min Delay (minutes)" slider (0-1440 mins).
        *   "Max Delay (minutes)" slider (0-1440 mins).
    *   Implemented dynamic UI logic:
        *   If "Enable Random Interval" is checked, the Min/Max sliders for
            that delay type become active, and the corresponding "Fixed Delay"
            number input is disabled.
        *   If unchecked, the Min/Max sliders are disabled, and the
            "Fixed Delay" number input is active.
    *   Initial interactive states of these inputs are set based on saved
        checkbox values.

2.  **Settings Management (`src/webui/components/agent_settings_tab.py`):**
    *   The `save_time_interval_settings` function has been updated to save
        the states of the "Enable Random Interval" checkboxes and the values
        of the Min/Max delay sliders to new environment variables (e.g.,
        `STEP_ENABLE_RANDOM_INTERVAL`, `STEP_MIN_DELAY_MINUTES`,
        `STEP_MAX_DELAY_MINUTES`).
    *   These new settings are loaded during UI initialization.

3.  **My Logic Modification (`src/agent/browser_use/browser_use_agent.py`):**
    *   The step delay logic in my `run` method now
        checks the `STEP_ENABLE_RANDOM_INTERVAL` environment variable.
    *   If random interval is enabled for steps:
        *   I retrieve the Min and Max step delay values (in minutes).
        *   Convert them to seconds.
        *   Ensure Min <= Max.
        *   Generate a random delay using `random.uniform(min_seconds, max_seconds)`.
        *   Apply this random delay using `asyncio.sleep()`.
        *   Log information about the random delay range and chosen value.
    *   If random interval is disabled, I fall back to the existing
        fixed delay mechanism using `STEP_DELAY_MINUTES`.
    *   Added `import random`.

**Limitations:**
*   The new interval delay logic currently only applies to
    **step delays**. Action and task delays, while having UI for interval
    configuration, do not yet utilize this randomization in my code
    due to previously identified structural constraints for implementing
    any form of action/task specific delays within `BrowserUseAgent`.

This feature provides you with more sophisticated control over my timing, allowing for less predictable and potentially more human-like pacing between steps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to configure random interval delays for step, action, and task operations in the agent settings UI.
  - Users can now enable random delay mode and set minimum and maximum delay values using interactive sliders for each delay type.
  - Introduced a new documentation guide outlining AI agent usage, testing, coding style, and conventions.
  - Enabled execution of multiple sequential actions with configurable delays between them.

- **Improvements**
  - Enhanced UI interactivity: toggling random interval mode dynamically enables or disables the relevant input controls.
  - Delay settings are automatically saved and applied when changed.
  - Generalized and consolidated delay handling logic to support both fixed and random interval delays across steps, actions, and tasks.
  - Improved agent configuration loading by merging UI and environment variable settings with type safety and default values.
  - Browser and agent settings tabs now load initial values from persistent environment settings for consistent configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->